### PR TITLE
Fix the package name in the installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 Install the core package and the provider(s) you need:
 
 ```bash
-composer require papi-ai/core
+composer require papi-ai/papi-core
 
 # Pick your provider(s)
 composer require papi-ai/anthropic   # Claude
@@ -22,6 +22,20 @@ For text-to-speech:
 
 ```bash
 composer require papi-ai/elevenlabs  # ElevenLabs TTS
+```
+
+Framework bridges, if you are not using Papi standalone:
+
+```bash
+composer require papi-ai/laravel     # Laravel service provider, config, facade
+composer require papi-ai/symfony     # Symfony bundle, DI, Messenger
+```
+
+Optional extras:
+
+```bash
+composer require papi-ai/effect      # Async video and fiber-based execution
+composer require papi-ai/rtk         # Token-optimisation proxy (needs the rtk binary)
 ```
 
 ## Requirements


### PR DESCRIPTION
`docs/installation.md` told readers to run `composer require papi-ai/core`. That package does not exist; ours is `papi-ai/papi-core`.

Verified every other package name on the page against its `composer.json`: this was the only wrong one.

Also adds the two framework bridges and the optional `effect` / `rtk` packages, which the page never listed.