### PR TITLE
Correct imageSize in the image contract, which is a string

### DIFF
--- a/src/Contracts/ImageProviderInterface.php
+++ b/src/Contracts/ImageProviderInterface.php
@@ -25,11 +25,14 @@ interface ImageProviderInterface
     /**
      * Generate images from a text prompt.
      *
+     * Providers name their own sizes, so `imageSize` is whatever string the provider
+     * understands: "1K", "2K" and "4K" on Google, "1024x1024" on OpenAI.
+     *
      * @param string $prompt The image generation prompt
      * @param array{
      *     model?: string,
      *     aspectRatio?: string,
-     *     imageSize?: int,
+     *     imageSize?: string,
      *     numberOfImages?: int,
      * } $options Provider-specific options
      * @return array{images: array<array{mimeType: string, data: string}>}
@@ -44,7 +47,7 @@ interface ImageProviderInterface
      * @param array{
      *     model?: string,
      *     aspectRatio?: string,
-     *     imageSize?: int,
+     *     imageSize?: string,
      * } $options Provider-specific options
      * @return array{images: array<array{mimeType: string, data: string}>, text: string}
      */


### PR DESCRIPTION
`ImageProviderInterface` declared `imageSize?: int` on both `generateImage()` and `editImage()`. No provider has ever honoured that: every provider names its own sizes and they are all strings. Google takes `"1K"`, `"2K"` and `"4K"`; OpenAI takes `"1024x1024"`.

This surfaced while fixing image generation in `papi-ai/google`. As soon as that provider's own docblock was corrected to `string`, Psalm rejected the implementation for not matching the interface, which is the contract pointing at its own error.

Correcting the contract rather than bending the provider back to `int` closes it at the source, and stops the next provider that implements this interface from inheriting the same wrong hint.

Docblock only. No behaviour changes, no signature changes, so this is a patch.