### PR TITLE
Correct the Google models in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,15 +264,15 @@ use PapiAI\Google\GoogleProvider;
 
 $provider = new GoogleProvider(
     apiKey: $_ENV['GOOGLE_API_KEY'],
-    defaultModel: GoogleProvider::MODEL_3_0_PRO,
+    defaultModel: GoogleProvider::MODEL_3_6_FLASH,
 );
 
 // Available models
-GoogleProvider::MODEL_3_1_PRO   // gemini-3.1-pro
-GoogleProvider::MODEL_3_0_PRO   // gemini-3.0-pro
-GoogleProvider::MODEL_2_0_FLASH // gemini-2.0-flash-exp
-GoogleProvider::MODEL_1_5_PRO   // gemini-1.5-pro
-GoogleProvider::MODEL_1_5_FLASH // gemini-1.5-flash
+GoogleProvider::MODEL_3_6_FLASH // gemini-3.6-flash (default)
+GoogleProvider::MODEL_3_5_FLASH // gemini-3.5-flash
+GoogleProvider::MODEL_3_1_PRO   // gemini-3.1-pro-preview
+GoogleProvider::MODEL_2_5_PRO   // gemini-2.5-pro
+GoogleProvider::MODEL_2_0_FLASH // gemini-2.0-flash
 ```
 
 ## Creating Custom Providers


### PR DESCRIPTION
The README's Google example used `MODEL_3_0_PRO` as its default, which was shut down on 9 March 2026, and listed the retired 1.5 pair.

It also mislabelled two constants that do still exist: `MODEL_2_0_FLASH` was shown as `gemini-2.0-flash-exp` and `MODEL_3_1_PRO` as `gemini-3.1-pro`. Neither string is the constant's actual value, so anyone copying the comment rather than the constant got a dead model ID.

Docs only, so no tag is needed.